### PR TITLE
Track message handler duration as prometheus metric

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ pollster = "0.2"
 event-listener = "2.4.0"
 log = "0.4"
 
+prometheus = { version = "0.13", optional = true }
+lazy_static = { version = "1", optional = true }
+
 # Feature `timing`
 futures-timer = { version = "3.0", optional = true, default-features = false }
 
@@ -57,6 +60,7 @@ with-smol-1 = ["smol"]
 with-tokio-1 = ["tokio"]
 with-wasm_bindgen-0_2 = ["wasm-bindgen", "wasm-bindgen-futures"]
 with-tracing-0_1 = ["tracing"]
+metrics = ["prometheus", "lazy_static"]
 
 [[example]]
 name = "basic_tokio"


### PR DESCRIPTION
This outputs stuff like:

```
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="0.000001"} 0
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="0.000002"} 0
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="0.000005"} 0
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="0.00001"} 0
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="0.0001"} 0
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="0.001"} 0
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="0.01"} 0
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="0.02"} 0
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="0.05"} 0
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="0.1"} 0
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="0.2"} 2
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="0.5"} 3
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="1"} 4
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="2"} 4
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="5"} 4
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="10"} 4
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="20"} 4
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="50"} 4
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="100"} 4
xtra_message_processing_duration_seconds_bucket{actor="daemon::monitor::Actor",message="daemon::monitor::Sync",le="+Inf"} 4
xtra_message_processing_duration_seconds_sum{actor="daemon::monitor::Actor",message="daemon::monitor::Sync"} 1.262331203
xtra_message_processing_duration_seconds_count{actor="daemon::monitor::Actor",message="daemon::monitor::Sync"} 4
```

From this we can calculate:

- Average execution time (`sum` / `count`)
- Apdex score: https://prometheus.io/docs/practices/histograms/#apdex-score
- Quantiles (like what is the execution time of 95% of message handlers): https://prometheus.io/docs/practices/histograms/#quantiles

I've chosen the histogram bins based on some experiments with a local release build. Even the most trivial message handlers like `oracle::NewAnnouncementFetched` which only modify a local hashmap are seldomly faster than `0.000001` seconds (averaging at 0.000002868 seconds):

```
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="0.000001"} 2
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="0.000002"} 3
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="0.000005"} 25
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="0.00001"} 26
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="0.0001"} 26
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="0.001"} 26
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="0.01"} 26
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="0.02"} 26
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="0.05"} 26
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="0.1"} 26
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="0.2"} 26
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="0.5"} 26
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="1"} 26
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="2"} 26
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="5"} 26
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="10"} 26
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="20"} 26
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="50"} 26
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="100"} 26
xtra_message_processing_duration_seconds_bucket{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched",le="+Inf"} 26
xtra_message_processing_duration_seconds_sum{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched"} 0.00007456299999999998
xtra_message_processing_duration_seconds_count{actor="daemon::oracle::Actor",message="daemon::oracle::NewAnnouncementFetched"} 26
```

We can modify these buckets later reasonably easy. For now, it would be nice to merge this an start experimenting with what kind of metrics we can draw from it!