### PR TITLE
Allow handlers to timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,10 +51,13 @@ smol = "1.1"
 smol-potat = "1.1"
 smol-timeout = "0.6"
 waker-fn = "1.1"
+tokio = { version = "1.18", features = ["macros"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "tracing-log"] }
 
 [features]
 default = ["timing"]
 timing = ["futures-timer"]
+timeout = ["futures-timer"]
 with-async_std-1 = ["async-std"]
 with-smol-1 = ["smol"]
 with-tokio-1 = ["tokio"]
@@ -94,6 +97,10 @@ required-features = ["with-smol-1"]
 [[test]]
 name = "basic"
 required-features = ["with-smol-1"]
+
+[[test]]
+name = "handler_timeout"
+required-features = ["timeout", "with-tokio-1", "tracing"]
 
 [workspace]
 members = ["examples/basic_wasm_bindgen"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, external_doc))]
 #![deny(unsafe_code, missing_docs)]
 
-pub use self::address::{Address, Disconnected, WeakAddress};
+pub use self::address::{Address, Error, WeakAddress};
 pub use self::context::{ActorShutdown, Context};
 pub use self::manager::ActorManager;
 

--- a/tests/handler_timeout.rs
+++ b/tests/handler_timeout.rs
@@ -1,0 +1,56 @@
+use std::time::Duration;
+use tracing_subscriber::util::SubscriberInitExt;
+use xtra::{prelude::*, Error};
+
+#[tokio::test]
+async fn handler_timeout_results_in_disconnected() {
+    let _guard = tracing_subscriber::fmt()
+        .with_env_filter("debug")
+        .with_test_writer()
+        .set_default();
+
+    let (address, context) = Context::new(None);
+    let context = context.with_handler_timeout(Duration::from_secs(1));
+    tokio::spawn(context.run(Sleeper {}));
+
+    let result = address.send(Sleep(Duration::from_secs(2))).await;
+
+    assert_eq!(
+        result,
+        Err(Error::TimedOut {
+            message: "handler_timeout::Sleep".to_string()
+        })
+    );
+}
+
+#[tokio::test]
+async fn no_handler_timeout_allows_handler_to_execute_normally() {
+    let (address, context) = Context::new(None);
+    tokio::spawn(context.run(Sleeper {}));
+
+    let result = address.send(Sleep(Duration::from_secs(2))).await;
+
+    assert!(result.is_ok());
+}
+
+struct Sleeper {}
+
+#[async_trait::async_trait]
+impl Actor for Sleeper {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
+
+struct Sleep(Duration);
+
+impl Message for Sleep {
+    type Result = ();
+}
+
+#[async_trait::async_trait]
+impl Handler<Sleep> for Sleeper {
+    async fn handle(&mut self, message: Sleep, _: &mut Context<Self>) {
+        tokio::time::sleep(message.0).await;
+    }
+}


### PR DESCRIPTION
TODO:

- [x] Change `Display` implementation on `Error` so that we provide more context on the actor and handler that failed.