### PR TITLE
Introduce more detailed metrics about message queuing and processing times

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -5,7 +5,7 @@ use futures_core::future::BoxFuture;
 use futures_util::FutureExt;
 
 use crate::context::Context;
-use crate::{Actor, Handler, Message, MessageName};
+use crate::{Actor, Handler, Message};
 
 /// A message envelope is a struct that encapsulates a message and its return channel sender (if applicable).
 /// Firstly, this allows us to be generic over returning and non-returning messages (as all use the
@@ -13,7 +13,7 @@ use crate::{Actor, Handler, Message, MessageName};
 /// allows us to erase the type of the message when this is in dyn Trait format, thereby being able to
 /// use only one channel to send all the kinds of messages that the actor can receives. This does,
 /// however, induce a bit of allocation (as envelopes have to be boxed).
-pub(crate) trait MessageEnvelope: Send + MessageName {
+pub(crate) trait MessageEnvelope: Send {
     /// The type of actor that this envelope carries a message for
     type Actor;
 
@@ -112,12 +112,6 @@ impl<A: Handler<M>, M: Message> MessageEnvelope for ReturningEnvelope<A, M> {
     }
 }
 
-impl<A: Handler<M>, M: Message> MessageName for ReturningEnvelope<A, M> {
-    fn name(&self) -> &'static str {
-        self.message.name()
-    }
-}
-
 /// An envelope that does not return a result from a message. Constructed  by the `AddressExt::do_send`
 /// method.
 pub(crate) struct NonReturningEnvelope<A, M: Message> {
@@ -166,12 +160,6 @@ impl<A: Handler<M>, M: Message> MessageEnvelope for NonReturningEnvelope<A, M> {
 
             act.handle(self.message, ctx).map(|_| ()).await
         })
-    }
-}
-
-impl<A: Handler<M>, M: Message> MessageName for NonReturningEnvelope<A, M> {
-    fn name(&self) -> &'static str {
-        self.message.name()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,19 +57,6 @@ pub trait Message: Send + 'static {
     type Result: Send;
 }
 
-pub(crate) trait MessageName {
-    fn name(&self) -> &'static str;
-}
-
-impl<M> MessageName for M
-where
-    M: Message,
-{
-    fn name(&self) -> &'static str {
-        std::any::type_name::<M>()
-    }
-}
-
 /// A trait indicating that an [`Actor`](trait.Actor.html) can handle a given [`Message`](trait.Message.html)
 /// asynchronously, and the logic to handle the message.
 ///


### PR DESCRIPTION
Previously, we only tracked how long it took for a message to execute.

We are now also introducing a histogram that tracks, how long it takes for messages to go from creation to processing, which is essentially the queuing / waiting time.

Together, these metrics can be used to track for example the rate at which we queue messages vs process them. The difference in the two _counts_ (queue vs process) will be the number of messages pending in the actors mailbox _per message_. Aggregating this difference via `sum by actor` will give the total number of messages pending in the actors mailbox.