### PR TITLE
Fix doctest that relied on stopping returning StopAll

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -157,10 +157,11 @@ impl<A, Rc: RefCounter> Address<A, Rc> {
     ///
     /// ```rust
     /// # use xtra::prelude::*;
+    /// # use xtra::KeepRunning;
     /// # use xtra::spawn::Smol;
     /// # use std::time::Duration;
     /// # struct MyActor;
-    /// # #[async_trait::async_trait] impl Actor for MyActor {type Stop = (); async fn stopped(self) -> Self::Stop {} }
+    /// # #[async_trait::async_trait] impl Actor for MyActor {type Stop = (); async fn stopped(self) -> Self::Stop {} async fn stopping(&mut self, ctx: &mut Context<Self>) -> KeepRunning { KeepRunning::StopAll } }
     /// # use smol::Timer;
     /// struct Shutdown;
     ///


### PR DESCRIPTION
In patch 95508e6a39a96721f7ca292a075ac7200b755a2e we modified the default behaviour of `Actor::stopping` to return
`KeepRunning::StopSelf`. This broke the example included with the docstring of `Address::is_connected`.

The example can be fixed by overwriting the implementation of `Actor::stopping`.